### PR TITLE
Update: Move AddWeixinEventSink<T>() to Weixin.Site project.

### DIFF
--- a/src/EfCore/WeixinSiteBuilderEfCoreExtensions.cs
+++ b/src/EfCore/WeixinSiteBuilderEfCoreExtensions.cs
@@ -182,13 +182,6 @@ public static class WeixinSiteBuilderEfCoreExtensions
         services.AddHostedService<WeixinSubscriberSyncHostedService>();
     }
 
-    public static WeixinSiteBuilder AddWeixinEventSink<TWeixinEventSink>(this WeixinSiteBuilder builder)
-        where TWeixinEventSink : class, IWeixinEventSink
-    {
-        builder.Services.Replace(ServiceDescriptor.Scoped<IWeixinEventSink, TWeixinEventSink>());
-        return builder;
-    }
-
     /// <summary>
     /// Finds a specific base type (generic or non-generic) in the inheritance hierarchy of a given type.
     /// </summary>

--- a/src/Site/WeixinSiteBuilderExtensions.cs
+++ b/src/Site/WeixinSiteBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Myvas.AspNetCore.Weixin;
@@ -8,10 +9,9 @@ namespace Myvas.AspNetCore.Weixin;
 public static class WeixinSiteBuilderExtensions
 {
     public static WeixinSiteBuilder AddWeixinEventSink<TWeixinEventSink>(this WeixinSiteBuilder builder)
-         where TWeixinEventSink : class, IWeixinEventSink
+        where TWeixinEventSink : class, IWeixinEventSink
     {
-        builder.Services.TryAddScoped<IWeixinEventSink, TWeixinEventSink>();
-
+        builder.Services.Replace(ServiceDescriptor.Scoped<IWeixinEventSink, TWeixinEventSink>());
         return builder;
     }
 }


### PR DESCRIPTION
Version: 9.0.0-rc.4

> The call is ambiguous between the following methods or properties: 'Microsoft.Extensions.DependencyInjection.WeixinSiteBuilderEfCoreExtensions.AddWeixinEventSink<TWeixinEventSink>(Myvas.AspNetCore.Weixin.WeixinSiteBuilder)' and 'Myvas.AspNetCore.Weixin.WeixinSiteBuilderExtensions.AddWeixinEventSink<TWeixinEventSink>(Myvas.AspNetCore.Weixin.WeixinSiteBuilder)'